### PR TITLE
update navigation and logo links to be non-relative

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -15,10 +15,10 @@ html(lang='en')
       div.navbar-inner
         div.container-fluid
           a.brand(href="/")
-            img(src=logo)
+            img(src='/img/logo.png')
           div.nav-collapse.collapse
             ul.nav
-              pages = {'new':'New Program', 'top':'Top Programs', 'random':'Random', 'io':'I/O Spec'}
+              pages = {'/new':'New Program', '/top':'Top Programs', '/random':'Random', '/io':'I/O Spec'}
               each v, k in pages
                 - if(current == k)
                   li.active: a(href="#{k}") #{v}


### PR DESCRIPTION
The top-bar navigation and logo links would fail when you are on a /fork/:id page since the links were relative paths. This diff updates the links to absolute paths from the site root.
